### PR TITLE
Fix bug in training error calculation

### DIFF
--- a/predictor.py
+++ b/predictor.py
@@ -56,8 +56,8 @@ class Predictor(object):
       predicted = self.predict(p[0], p[1])
       training_errors.append(predicted / p[2])
 
-    training_errors = [abs(i-1.0) for i in training_errors]
-    print "Average training error %f%%" % (np.mean(training_errors)*100.0 )
+    training_errors = [str(np.around(i*100, 2)) + "%" for i in training_errors]
+    print "Prediction ratios are", ", ".join(training_errors)
     return self.model[0]
 
   def num_examples(self):

--- a/predictor.py
+++ b/predictor.py
@@ -56,7 +56,8 @@ class Predictor(object):
       predicted = self.predict(p[0], p[1])
       training_errors.append(predicted / p[2])
 
-    print "Average training error %f%%" % ((np.mean(training_errors) - 1.0)*100.0 )
+    training_errors = [abs(i-1.0) for i in training_errors]
+    print "Average training error %f%%" % (np.mean(training_errors)*100.0 )
     return self.model[0]
 
   def num_examples(self):


### PR DESCRIPTION
Previously, the training error is calculated by the `abs( avg(predicted_time/rea_time)-1.0 )`, which is wrong because predicted_time can be larger or smaller than real_time. And according to the given sample, the value is 0.053681%, which is too low to be the truth.
Therefore, I adjust the formula and now it is `avg( abs(predicted_time/rea_time-1.0) )`. And according to the given sample, the value is 1.335098% now, which is more consistent with the results of your experiments actually.